### PR TITLE
Fix pkg-config calls for GL and python libraries

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -11,9 +11,9 @@ SDLCFLAGS = $(shell sdl-config --cflags)
 SDLLIBS = $(shell sdl-config --libs) $(shell pkg-config SDL_image SDL_mixer --libs)
 
 GLCFLAGS = $(shell pkg-config glu --cflags)
-GLLIBS = -lglut $(shell pkg-config glu --libs)
+GLLIBS = -lglut $(shell pkg-config glu gl --libs)
 
-PYTHONLIBS = $(shell python3-config --ldflags)
+PYTHONLIBS = $(shell python3-config --ldflags --embed)
 
 # change this, if the kodilib directory isn't parallel to the kiki directory
 


### PR DESCRIPTION
Without `pkg-config gl`, I get undefined references to various OpenGL functions such as `glLightfv` as well as `/usr/lib64/libGL.so.1: error adding symbols: DSO missing from command line`

Without `python3-config --embed`, it does not emit `-lpython3.x` and I get a mountain of undefined references to various Python functions - see https://bugs.python.org/issue36721

I also ran into https://sourceforge.net/p/freeglut/bugs/255/ although it's fixed in the recent `freeglut-3.2.2` release.

Thanks for resurrecting this amazing game!